### PR TITLE
Adding ability to use `mongodb-srv` URLs for hosts using DNS SRV records.

### DIFF
--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -34,6 +34,25 @@ This consists of two steps and one optional step.
 
 .. _pop_db:
 
+Connecting to MongoDB
+---------------------
+
+MongoDB has two possible syntax for connecting to the database.
+
+* `mongodb://` - Default
+* `mongodb+srv://`
+
+The default syntax allows for connectivity to a single host or a replica set.  The SRV syntax
+allows for connecting using a  single DNS hostname which seeds multiple hosts in a replica set.
+The SRV DNS record contains all of the details required for connecting to any server contained
+in a replia set, even if one of the nodes is unavailable.
+
+To enable the SRV scheme, set the variable `DnsSrvRecord` to `True` in the configuration.ini file.
+For more information, read `MongoDB 3.6: Here to SRV you with easier replica set connections <https://www.mongodb.com/developer/article/srv-connection-strings/>`.
+
+*Note:* MongoDB Atlas requires the use of the SRV scheme.
+
+
 Populating the database
 -----------------------
 

--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -50,7 +50,7 @@ in a replia set, even if one of the nodes is unavailable.
 To enable the SRV scheme, set the variable `DnsSrvRecord` to `True` in the configuration.ini file.
 For more information, read `MongoDB 3.6: Here to SRV you with easier replica set connections <https://www.mongodb.com/developer/article/srv-connection-strings/>`.
 
-*Note:* MongoDB Atlas requires the use of the SRV scheme.
+*Note:* MongoDB Atlas requires the use of the SRV syntax.
 
 
 Populating the database

--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -11,6 +11,9 @@ RefDB: 12
 Host: localhost
 Port: 27017
 DB: cvedb
+Username:
+Password:
+DnsSrvRecord: False
 PluginName: mongodb
 
 [dbmgt]

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -47,6 +47,7 @@ class Configuration:
         "mongoDB": "cvedb",
         "mongoUsername": "",
         "mongoPassword": "",
+        "mongoSrv": False,
         "DatabasePluginName": "mongodb",
         "flaskHost": "127.0.0.1",
         "flaskPort": 5000,

--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -15,7 +15,7 @@ from lib.Config import Configuration
 
 config = Configuration()
 
-
+DNSSRV = config.readSetting("Database", "DnsSrvRecord", config.default["mongoSrv"])
 HOST = config.readSetting("Database", "Host", config.default["mongoHost"])
 PORT = config.readSetting("Database", "Port", config.default["mongoPort"])
 DATABASE = config.getMongoDB()
@@ -34,13 +34,26 @@ class MongoPlugin(DatabasePluginBase):
         """
         super().__init__()
 
-        if USERNAME and PASSWORD:
+        if USERNAME and PASSWORD and DNSSRV is True:
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+                username=USERNAME,
+                password=PASSWORD,
+                host=HOST,
+                db=DATABASE
+            )
+        elif USERNAME and PASSWORD and DNSSRV is not True:
             mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
-                username=USERNAME, password=PASSWORD, host=HOST, port=PORT, db=DATABASE
+                username=USERNAME,
+                password=PASSWORD,
+                host=HOST,
+                port=PORT,
+                db=DATABASE
             )
         else:
             mongoURI = "mongodb://{host}:{port}/{db}".format(
-                host=HOST, port=PORT, db=DATABASE
+                host=HOST,
+                port=PORT,
+                db=DATABASE
             )
 
         connect = pymongo.MongoClient(mongoURI, connect=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ ansicolors==1.1.8
 nltk==3.6.5
 nested-lookup==0.2.23
 oauthlib==3.1.1
+dnspython==2.1.0


### PR DESCRIPTION
Added:
* Added feature to use mongodb-srv URI records in mongodb plugin. 
* Added URI configuration options in Config.py. 
* Updated sample configuration to include ability to enable mongodb-srv URI. 
* Added dnspython to pip requirements.txt.

ToDo:
* Update documentation to reflect changes to sample configuration file.
* Test deployment against dev systems.