### PR TITLE
Add authentication database variables

### DIFF
--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -56,7 +56,7 @@ Database User Authentication
 ----------------------------
 
 When passing a username and password, CVE-Search submits the values against the default `admin` 
-database. If the authentication information is stored in a seperate database other than `admin`, 
+database. If the authentication information is stored in a database other than `admin`, 
 authentication attempts will fail.
 
 To change the default authentiation database, set the variable `AuthDB` in the configuration.ini file.

--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -52,6 +52,14 @@ For more information, read `MongoDB 3.6: Here to SRV you with easier replica set
 
 *Note:* MongoDB Atlas requires the use of the SRV syntax.
 
+Database User Authentication
+----------------------------
+
+When passing a username and password, CVE-Search submits the values against the default `admin` 
+database. If the authentication information is stored in a seperate database other than `admin`, 
+authentication attempts will fail.
+
+To change the default authentiation database, set the variable `AuthDB` in the configuration.ini file.
 
 Populating the database
 -----------------------

--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -14,6 +14,7 @@ DB: cvedb
 Username:
 Password:
 DnsSrvRecord: False
+AuthDB: admin
 PluginName: mongodb
 
 [dbmgt]

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -48,6 +48,7 @@ class Configuration:
         "mongoUsername": "",
         "mongoPassword": "",
         "mongoSrv": False,
+        "mongoAuth": "admin",
         "DatabasePluginName": "mongodb",
         "flaskHost": "127.0.0.1",
         "flaskPort": 5000,
@@ -136,6 +137,7 @@ class Configuration:
         mongoSrv = cls.readSetting("Database", "DnsSrvRecord", cls.default["mongoSrv"])
         mongoHost = cls.readSetting("Database", "Host", cls.default["mongoHost"])
         mongoPort = cls.readSetting("Database", "Port", cls.default["mongoPort"])
+        mongoAuth = cls.readSetting("Database", "AuthDB", cls.default["mongoAuth"])
         mongoDB = cls.getMongoDB()
         mongoUsername = urllib.parse.quote(
             cls.readSetting("Database", "Username", cls.default["mongoUsername"])
@@ -144,19 +146,21 @@ class Configuration:
             cls.readSetting("Database", "Password", cls.default["mongoPassword"])
         )
         if mongoUsername and mongoPassword and mongoSrv is True:
-            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?authSource={auth}&retryWrites=true&w=majority".format(
                 username=mongoUsername,
                 password=mongoPassword,
                 host=mongoHost,
-                db=mongoDB
+                db=mongoDB,
+                auth=mongoAuth
             )
         elif mongoUsername and mongoPassword:
-            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
+            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}?authSource={auth}".format(
                 username=mongoUsername,
                 password=mongoPassword,
                 host=mongoHost,
                 port=mongoPort,
                 db=mongoDB,
+                auth=mongoAuth
             )
         else:
             mongoURI = "mongodb://{host}:{port}/{db}".format(

--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -18,6 +18,7 @@ config = Configuration()
 DNSSRV = config.readSetting("Database", "DnsSrvRecord", config.default["mongoSrv"])
 HOST = config.readSetting("Database", "Host", config.default["mongoHost"])
 PORT = config.readSetting("Database", "Port", config.default["mongoPort"])
+AUTH = config.readSetting("Database", "AuthDB", config.default["mongoAuth"])
 DATABASE = config.getMongoDB()
 USERNAME = urllib.parse.quote(
     config.readSetting("Database", "Username", config.default["mongoUsername"])
@@ -35,19 +36,21 @@ class MongoPlugin(DatabasePluginBase):
         super().__init__()
 
         if USERNAME and PASSWORD and DNSSRV is True:
-            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?authSource={auth}&retryWrites=true&w=majority".format(
                 username=USERNAME,
                 password=PASSWORD,
                 host=HOST,
-                db=DATABASE
+                db=DATABASE,
+                auth=AUTH
             )
         elif USERNAME and PASSWORD:
-            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
+            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}?authSource={auth}".format(
                 username=USERNAME,
                 password=PASSWORD,
                 host=HOST,
                 port=PORT,
-                db=DATABASE
+                db=DATABASE,
+                auth=AUTH
             )
         else:
             mongoURI = "mongodb://{host}:{port}/{db}".format(


### PR DESCRIPTION
When attempting to pass a username and password, the authentication fails with the following error:

```
pymongo.errors.OperationFailure: Authentication failed., full error: {'ok': 0.0, 'errmsg': 'Authentication failed.', 'code': 18, 'codeName': 'AuthenticationFailed'}
```

For testing, printed out the connection string used by the `db_updater.py` script and used it against the Mongo Shell tool.  The same error occurred.  The connection string used was:

```
mongodb://root:example@192.168.0.65:27017/cvedb
```

Tested the same connection string but passing the `authSource` variable as part of the connection string, which resolved the error.

```
mongodb://root:example@192.168.0.65:27017/cvedb-eddard?authSource=admin
```

This update adds the `authSource` variable to the connection string anytime a user/pass exists.  By default, it will use the `admin` database, but it can be updated in the `configuration.ini` file by changing the variable `AuthDB`.